### PR TITLE
Fix monocypher.argon2i_32

### DIFF
--- a/c_monocypher.pyx
+++ b/c_monocypher.pyx
@@ -12,7 +12,7 @@ import warnings
 
 
 # also edit setup.py
-__version__ = '4.0.2.3'   # also change setup.py
+__version__ = '4.0.2.4'   # also change setup.py
 __title__ = 'pymonocypher'
 __description__ = 'Python ctypes bindings to the Monocypher library'
 __url__ = 'https://github.com/jetperch/pymonocypher'

--- a/c_monocypher.pyx
+++ b/c_monocypher.pyx
@@ -325,7 +325,7 @@ def argon2i_32(nb_blocks, nb_iterations, password, salt, key=None, ad=None) -> b
 
     cdef crypto_argon2_config config;
     config.algorithm = 1
-    config.nb_block = nb_blocks
+    config.nb_blocks = nb_blocks
     config.nb_passes = nb_iterations
     config.nb_lanes = 1
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 import os
 
 MYPATH = os.path.abspath(os.path.dirname(__file__))
-VERSION = '4.0.2.3'  # also change c_monocypher.pyx
+VERSION = '4.0.2.4'  # also change c_monocypher.pyx
 
 
 try:


### PR DESCRIPTION
While using pymonocypher for a cryptographic protocol, we encountered an AttributeError:

    File "c_monocypher.pyx", line 328, in monocypher.argon2i_32
  AttributeError: 'dict' object has no attribute 'nb_block'

Using the Python console to reproduce the error with monocypher 4.0.2.3:

>>> import monocypher
>>> monocypher.argon2i_32(nb_blocks=100000, nb_iterations=3,
                          password=password, salt=salt, key=None,
                          ad=None)

This will result in the following exception:

   Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "c_monocypher.pyx", line 328, in monocypher.argon2i_32
  AttributeError: 'dict' object has no attribute 'nb_block'

It appears that the c_monocypher.pyx is defined in the singular 'nb_block' for the binding when it should be 'nb_blocks'. After changing that value to 'nb_blocks', it works as expected:

  >>> password  = b'123456'
  >>> salt = b'00125235'
  >>> monocypher.argon2i_32(nb_blocks=100000, nb_iterations=3,
                            password=password, salt=salt, key=None,
                            ad=None)

This produces a bytes object as expected:

  b'\x8cj\x88\xc7\xda}\x7f\x18Z\x01\xbf\xbb\xd5\x01\x13\xd9<\xb4\xb9\'c\x8f\x98\xee\x96\x04E-\xfc"\xd9o'