### PR TITLE
Opt no wipe argon2 32 pyx

### DIFF
--- a/c_monocypher.pyx
+++ b/c_monocypher.pyx
@@ -12,7 +12,7 @@ import warnings
 
 
 # also edit setup.py
-__version__ = '4.0.2.3'   # also change setup.py
+__version__ = '4.0.2.4'   # also change setup.py
 __title__ = 'pymonocypher'
 __description__ = 'Python ctypes bindings to the Monocypher library'
 __url__ = 'https://github.com/jetperch/pymonocypher'

--- a/c_monocypher.pyx
+++ b/c_monocypher.pyx
@@ -319,7 +319,7 @@ cdef uint32_t _validate_u32(variable_name, value):
     return <uint32_t> value
 
 
-def argon2i_32(nb_blocks, nb_iterations, password, salt, key=None, ad=None) -> bytes:
+def argon2i_32(nb_blocks, nb_iterations, password, salt, key=None, ad=None, _wipe=True) -> bytes:
     key = b'' if key is None else key
     ad = b'' if ad is None else ad
 
@@ -347,7 +347,8 @@ def argon2i_32(nb_blocks, nb_iterations, password, salt, key=None, ad=None) -> b
         crypto_argon2(hash, <uint32_t> len(hash), work_area, config, inputs, extras)
     finally:
         free(work_area)
-    crypto_wipe(password, len(password))
+    if _wipe:
+        crypto_wipe(password, len(password))
     return hash
 
 

--- a/c_monocypher.pyx
+++ b/c_monocypher.pyx
@@ -325,7 +325,7 @@ def argon2i_32(nb_blocks, nb_iterations, password, salt, key=None, ad=None) -> b
 
     cdef crypto_argon2_config config;
     config.algorithm = 1
-    config.nb_block = nb_blocks
+    config.nb_blocks = nb_blocks
     config.nb_passes = nb_iterations
     config.nb_lanes = 1
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 import os
 
 MYPATH = os.path.abspath(os.path.dirname(__file__))
-VERSION = '4.0.2.3'  # also change c_monocypher.pyx
+VERSION = '4.0.2.4'  # also change c_monocypher.pyx
 
 
 try:


### PR DESCRIPTION
On line 350 of `c_monocypher.pyx` there is an unconditional call to `crypto_wipe`. Starting on line 155 the definition of `wipe`  includes a comment that says: "WARNING: this violates the Python memory model and may result in corrupted data.  Ensure that the data to wipe is the only active reference!"""

While developing a cryptographic protocol that optionally uses very short passwords, we appear to have encountered this issue. We outlined this finding in our comments but we only seem to trigger it for passwords with a length that is less than two bytes: https://codeberg.org/rendezvous/reunion/src/branch/main/reunion/primitives.py#L17 We additionally make a copy of the original password for use over long periods of time.

We would prefer to not corrupt memory for the single password cases in our protocol, if that is indeed happening. We would also prefer not to need to make a copy of the original passphrase to work around this specific use case as erasing the password in memory is problematic for long running protocol runs.

This change optionally allows a caller to avoid `argon2i_32` calling `wipe`  or `crypto_wipe` internally by passing the optional value `_wipe=False` when using  `argon2i_32` . By default the original behavior is retained (e.g.: `_wipe=True` and `wipe` is called by  `argon2i_32` ). This change would only impact callers who want to disable wiping.