### PR TITLE
2026 Feb 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 This file contains the list of changes made to pymonocypher.
 
 
+# 4.0.2.7
+
+2026 Feb 12
+
+* Addressed [Issue #18](https://github.com/jetperch/pymonocypher/issues/18)
+  * Added `x25519()` function exposing the raw X25519 shared secret primitive.
+  * Added `x25519_public_key()` function to compute X25519 public keys.
+  * Added `chacha20_h()` function exposing HChacha20 for key derivation.
+  * Deprecated `key_exchange()` — use `x25519()` with a KDF instead.
+  * Deprecated `compute_key_exchange_public_key()` — use `x25519_public_key()` instead.
+  * Deprecated `generate_key_exchange_key_pair()` — use `generate_key()` and `x25519_public_key()` instead.
+
+
 # 4.0.2.6
 
 2025 Dec 2

--- a/c_monocypher.pyx
+++ b/c_monocypher.pyx
@@ -352,25 +352,93 @@ def argon2i_32(nb_blocks, nb_iterations, password, salt, key=None, ad=None, _wip
     return hash
 
 
+def x25519_public_key(secret_key: bytes) -> bytes:
+    """Compute the X25519 public key from a secret key.
+
+    :param secret_key: The 32-byte secret key.
+    :return: The 32-byte public key.
+    """
+    if len(secret_key) != 32:
+        raise ValueError(f'Invalid secret_key length {len(secret_key)} != 32')
+    public_key = bytes(32)
+    crypto_x25519_public_key(public_key, secret_key)
+    return public_key
+
+
+def x25519(your_secret_key: bytes, their_public_key: bytes) -> bytes:
+    """Compute the raw X25519 shared secret.
+
+    WARNING: The raw shared secret is not uniformly random.
+    Do not use it directly as a session key.
+    You MUST apply a key derivation function (KDF) such as
+    crypto_chacha20_h (HChacha20) or BLAKE2b before use.
+
+    :param your_secret_key: Your private, secret 32-byte key.
+    :param their_public_key: Their public 32-byte key.
+    :return: The 32-byte raw shared secret.
+    """
+    if len(your_secret_key) != 32:
+        raise ValueError(f'Invalid your_secret_key length {len(your_secret_key)} != 32')
+    if len(their_public_key) != 32:
+        raise ValueError(f'Invalid their_public_key length {len(their_public_key)} != 32')
+    shared_secret = bytes(32)
+    crypto_x25519(shared_secret, your_secret_key, their_public_key)
+    return shared_secret
+
+
+def chacha20_h(key: bytes, input: bytes) -> bytes:
+    """Compute HChacha20 (the hash variant of ChaCha20).
+
+    This is useful as a key derivation function (KDF) to derive
+    a uniformly random session key from a raw X25519 shared secret.
+
+    :param key: The 32-byte key (e.g., raw X25519 shared secret).
+    :param input: The 16-byte input (typically all zeros for KDF usage).
+    :return: The 32-byte derived key.
+    """
+    if len(key) != 32:
+        raise ValueError(f'Invalid key length {len(key)} != 32')
+    if len(input) != 16:
+        raise ValueError(f'Invalid input length {len(input)} != 16')
+    out = bytes(32)
+    crypto_chacha20_h(out, key, input)
+    return out
+
+
 def compute_key_exchange_public_key(secret_key: bytes) -> bytes:
     """Generate the public key for key exchange from the secret key.
+
+    .. deprecated:: 4.0.2.7
+        Use :func:`x25519_public_key` instead.
 
     :param secret_key: The 32-byte secret key.
     :return: The 32-byte public key for :func:`key_exchange`.
     """
+    warnings.warn(
+        'compute_key_exchange_public_key() is deprecated, use x25519_public_key() instead',
+        DeprecationWarning, stacklevel=2)
     public_key = bytes(32)
     crypto_x25519_public_key(public_key, secret_key)
     return public_key
 
 
 def key_exchange(your_secret_key: bytes, their_public_key: bytes) -> bytes:
-    """Compute a shared secret based upon public-key crytography.
+    """Compute a shared secret based upon public-key cryptography.
+
+    .. deprecated:: 4.0.2.7
+        Use :func:`x25519` combined with a key derivation function
+        such as :func:`chacha20_h` or :func:`blake2b` instead.
 
     :param your_secret_key: Your private, secret 32-byte key.
     :param their_public_key: Their public 32-byte key.
     :return: A 32-byte shared secret that can will match what is
         computed using their_secret_key and your_public_key.
     """
+    warnings.warn(
+        'key_exchange() is deprecated. Use x25519() combined with a KDF '
+        '(e.g., chacha20_h() or blake2b()) instead. '
+        'The raw X25519 output is not suitable for direct use as a key.',
+        DeprecationWarning, stacklevel=2)
     p = bytes(32)
     crypto_x25519(p, your_secret_key, their_public_key)
     return p
@@ -479,10 +547,17 @@ def generate_signing_key_pair() -> tuple[bytes, bytes]:
 def generate_key_exchange_key_pair() -> tuple[bytes, bytes]:
     """Generate a new keypair for key exchange using default settings.
 
+    .. deprecated:: 4.0.2.7
+        Use :func:`generate_key` and :func:`x25519_public_key` instead.
+
     :return: (secret, public)
     """
+    warnings.warn(
+        'generate_key_exchange_key_pair() is deprecated. '
+        'Use generate_key() and x25519_public_key() instead.',
+        DeprecationWarning, stacklevel=2)
     secret = generate_key()
-    public = compute_key_exchange_public_key(secret)
+    public = x25519_public_key(secret)
     return secret, public
 
 

--- a/test/test_monocypher.py
+++ b/test/test_monocypher.py
@@ -132,14 +132,18 @@ class TestMonocypher(unittest.TestCase):
         expect = b'l#\x84\xf2\xc0\xf1:\x8f\xf3\xce\xeeU\x07U@w\x8c\xd9\xf9C\x83\x17\x887\xae$\xf9\xf4\x19\xc1-{'
         your_secret_key = bytes(range(32))
         their_public_key = bytes(range(32, 64))
-        shared_key = monocypher.key_exchange(your_secret_key, their_public_key)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            shared_key = monocypher.key_exchange(your_secret_key, their_public_key)
         self.assertEqual(expect, shared_key)
 
     def test_key_exchange_random(self):
-        a_private_secret, a_public_secret = monocypher.generate_key_exchange_key_pair()
-        b_private_secret, b_public_secret = monocypher.generate_key_exchange_key_pair()
-        b_shared_secret = monocypher.key_exchange(b_private_secret, a_public_secret)
-        a_shared_secret = monocypher.key_exchange(a_private_secret, b_public_secret)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            a_private_secret, a_public_secret = monocypher.generate_key_exchange_key_pair()
+            b_private_secret, b_public_secret = monocypher.generate_key_exchange_key_pair()
+            b_shared_secret = monocypher.key_exchange(b_private_secret, a_public_secret)
+            a_shared_secret = monocypher.key_exchange(a_private_secret, b_public_secret)
         self.assertEqual(a_shared_secret, b_shared_secret)
 
     def test_generate_key(self):
@@ -176,6 +180,110 @@ class TestMonocypher(unittest.TestCase):
                 pass
         curve2 = monocypher.elligator_map(hidden2)
         self.assertEqual(curve1, curve2)
+
+    def test_x25519_public_key(self):
+        secret_key = bytes(range(32))
+        public_key = monocypher.x25519_public_key(secret_key)
+        self.assertEqual(32, len(public_key))
+        # Same underlying call as compute_key_exchange_public_key
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            expected = monocypher.compute_key_exchange_public_key(secret_key)
+        self.assertEqual(expected, public_key)
+
+    def test_x25519_public_key_invalid_length(self):
+        with self.assertRaises(ValueError):
+            monocypher.x25519_public_key(b'\x00' * 16)
+
+    def test_x25519_static(self):
+        """x25519() should produce the same output as the current key_exchange()."""
+        your_secret_key = bytes(range(32))
+        their_public_key = bytes(range(32, 64))
+        shared = monocypher.x25519(your_secret_key, their_public_key)
+        self.assertEqual(32, len(shared))
+        # Must match current key_exchange output (same underlying crypto_x25519 call)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            expected = monocypher.key_exchange(your_secret_key, their_public_key)
+        self.assertEqual(expected, shared)
+
+    def test_x25519_roundtrip(self):
+        secret_a = monocypher.generate_key()
+        secret_b = monocypher.generate_key()
+        public_a = monocypher.x25519_public_key(secret_a)
+        public_b = monocypher.x25519_public_key(secret_b)
+        shared_ab = monocypher.x25519(secret_a, public_b)
+        shared_ba = monocypher.x25519(secret_b, public_a)
+        self.assertEqual(shared_ab, shared_ba)
+
+    def test_x25519_invalid_length(self):
+        with self.assertRaises(ValueError):
+            monocypher.x25519(b'\x00' * 16, b'\x00' * 32)
+        with self.assertRaises(ValueError):
+            monocypher.x25519(b'\x00' * 32, b'\x00' * 16)
+
+    def test_chacha20_h(self):
+        key = bytes(range(32))
+        input_bytes = bytes(16)
+        result = monocypher.chacha20_h(key, input_bytes)
+        self.assertEqual(32, len(result))
+        # Deterministic: same inputs produce same output
+        self.assertEqual(result, monocypher.chacha20_h(key, input_bytes))
+        # Different inputs produce different output
+        different_input = bytes(range(16))
+        self.assertNotEqual(result, monocypher.chacha20_h(key, different_input))
+
+    def test_chacha20_h_invalid_length(self):
+        with self.assertRaises(ValueError):
+            monocypher.chacha20_h(b'\x00' * 16, b'\x00' * 16)
+        with self.assertRaises(ValueError):
+            monocypher.chacha20_h(b'\x00' * 32, b'\x00' * 8)
+
+    def test_chacha20_h_as_kdf(self):
+        """Demonstrate using chacha20_h as a KDF after x25519, replicating v3 key_exchange behavior."""
+        secret_a = monocypher.generate_key()
+        secret_b = monocypher.generate_key()
+        public_a = monocypher.x25519_public_key(secret_a)
+        public_b = monocypher.x25519_public_key(secret_b)
+        raw_ab = monocypher.x25519(secret_a, public_b)
+        raw_ba = monocypher.x25519(secret_b, public_a)
+        # Derive session keys using HChacha20
+        derived_ab = monocypher.chacha20_h(raw_ab, bytes(16))
+        derived_ba = monocypher.chacha20_h(raw_ba, bytes(16))
+        self.assertEqual(derived_ab, derived_ba)
+        # Derived key differs from raw shared secret
+        self.assertNotEqual(raw_ab, derived_ab)
+
+    def test_key_exchange_deprecation_warning(self):
+        your_secret_key = bytes(range(32))
+        their_public_key = bytes(range(32, 64))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            monocypher.key_exchange(your_secret_key, their_public_key)
+            self.assertEqual(1, len(w))
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn('x25519()', str(w[0].message))
+
+    def test_compute_key_exchange_public_key_deprecation_warning(self):
+        secret_key = bytes(range(32))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            monocypher.compute_key_exchange_public_key(secret_key)
+            self.assertEqual(1, len(w))
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn('x25519_public_key()', str(w[0].message))
+
+    def test_generate_key_exchange_key_pair_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            secret, public = monocypher.generate_key_exchange_key_pair()
+            self.assertEqual(1, len(w))
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn('generate_key()', str(w[0].message))
+        # Still produces valid keys
+        self.assertEqual(32, len(secret))
+        self.assertEqual(32, len(public))
+        self.assertEqual(monocypher.x25519_public_key(secret), public)
 
     def test_argon2i_32(self):
         expect = b'm\xf3pIA\xe4#\x92\x89h\x9cI\x9c\x08\xbe\xc4v\xb2\xc5\x8c\xa4\x1cV\x9a\xd2b\x0e\x96oer\x02'


### PR DESCRIPTION
Addressed [Issue #18](https://github.com/jetperch/pymonocypher/issues/18)

* Added `x25519()` function exposing the raw X25519 shared secret primitive.
* Added `x25519_public_key()` function to compute X25519 public keys.
* Added `chacha20_h()` function exposing HChacha20 for key derivation.
* Deprecated `key_exchange()` — use `x25519()` with a KDF instead.
* Deprecated `compute_key_exchange_public_key()` — use `x25519_public_key()` instead.
* Deprecated `generate_key_exchange_key_pair()` — use `generate_key()` and `x25519_public_key()` instead.